### PR TITLE
Simplify background map details

### DIFF
--- a/Map Map/Background Map/Background Map Layers/BackgroundMapButtonsV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapButtonsV.swift
@@ -95,7 +95,7 @@ struct BackgroundMapButtonsV: View {
         }
         .animation(.easeInOut, value: markerButton)
         .mapScope(mapScope)
-        .onChange(of: backgroundMapDetails.position) { checkOverMarker() }
+        .onChange(of: backgroundMapDetails.region.center) { checkOverMarker() }
         .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)) { _ in
             checkOverMarker()
         }
@@ -122,7 +122,7 @@ struct BackgroundMapButtonsV: View {
     }
     
     func addMarker() {
-        let newMarker = Marker(coordinates: backgroundMapDetails.position, insertInto: moc)
+        let newMarker = Marker(coordinates: backgroundMapDetails.region.center, insertInto: moc)
         let centerPoint: CGPoint = CGPoint(size: screenSize / 2)
         for mapMap in mapMaps {
             if let path = BackgroundMap.generateMapMapRotatedConvexHull(

--- a/Map Map/Background Map/Background Map Layers/BackgroundMapHudV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapHudV.swift
@@ -32,11 +32,11 @@ struct BackgroundMapHudV: View {
         HStack(spacing: 0) {
             VStack(alignment: .leading) {
                 Text("Latitude: ") +
-                Text(locationDisplayMode.degreesToString(latitude: backgroundMapDetails.position.latitude))
+                Text(locationDisplayMode.degreesToString(latitude: backgroundMapDetails.region.center.latitude))
                     .fontWidth(.condensed)
                 
                 Text("Longitude: ") +
-                Text(locationDisplayMode.degreesToString(longitude: backgroundMapDetails.position.longitude))
+                Text(locationDisplayMode.degreesToString(longitude: backgroundMapDetails.region.center.longitude))
                     .fontWidth(.condensed)
                 if showHeading {
                     Text("Heading: ") +
@@ -52,11 +52,11 @@ struct BackgroundMapHudV: View {
         .clipShape(RoundedRectangle(cornerRadius: 11))
         .contextMenu {
             Button {
-                let placemark = MKPlacemark(coordinate: backgroundMapDetails.position)
+                let placemark = MKPlacemark(coordinate: backgroundMapDetails.region.center)
                 let mapItem = MKMapItem(placemark: placemark)
                 let launchOptions: [String : Any] = [
-                    MKLaunchOptionsMapCenterKey: backgroundMapDetails.position,
-                    MKLaunchOptionsMapSpanKey: backgroundMapDetails.span
+                    MKLaunchOptionsMapCenterKey: backgroundMapDetails.region.center,
+                    MKLaunchOptionsMapSpanKey: backgroundMapDetails.region.span
                 ]
                 mapItem.openInMaps(launchOptions: launchOptions)
             } label: {
@@ -79,9 +79,9 @@ struct BackgroundMapHudV: View {
             }
 
         }
-        .onChange(of: backgroundMapDetails.rotation) { _, update in
+        .onChange(of: backgroundMapDetails.mapCamera) { _, update in
             withAnimation {
-                showHeading = update.degrees != .zero
+                showHeading = -update.heading != 0
             }
         }
         .gesture(tap)

--- a/Map Map/Background Map/Background Map Layers/BackgroundMapLayersV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapLayersV.swift
@@ -48,7 +48,7 @@ struct BackgroundMapLayersV: View {
                 CrosshairV()
                     .allowsHitTesting(false)
                     .opacity(crosshairOpacity)
-                    .onChange(of: backgroundMapDetails.position) {
+                    .onChange(of: backgroundMapDetails.region.center) {
                         if timer != nil {
                             withAnimation(.easeInOut(duration: 0.1)) {
                                 crosshairOpacity = 1

--- a/Map Map/Background Map/Background Map Layers/BackgroundMapPointsV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapPointsV.swift
@@ -67,8 +67,8 @@ struct BackgroundMapPointsV: View {
                         } label: {
                             MarkerV(marker: marker)
                                 .rotationEffect(
-                                    backgroundMapDetails.rotation -
-                                    Angle(degrees: marker.lockRotationAngleDouble ?? backgroundMapDetails.rotation.degrees)
+                                    Angle(degrees: -backgroundMapDetails.mapCamera.heading -
+                                          (marker.lockRotationAngleDouble ?? -backgroundMapDetails.mapCamera.heading))
                                 )
                                 .offset(y: markerOffset)
                         }
@@ -113,19 +113,19 @@ struct BackgroundMapPointsV: View {
             .animation(.linear, value: ssUserLocation)
         }
         .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextObjectsDidChange)) { interpretCDNotification($0) }
-        .onChange(of: backgroundMapDetails.position) {
+        .onChange(of: backgroundMapDetails.region.center) {
             Task {
                 let positions = await calculateSSlineEndPos()
                 DispatchQueue.main.async { self.lineEnds = positions }
             }
         }
-        .onChange(of: backgroundMapDetails.rotation) {
+        .onChange(of: backgroundMapDetails.mapCamera.heading) {
             Task {
                 let positions = await calculateSSlineEndPos()
                 DispatchQueue.main.async { self.lineEnds = positions }
             }
         }
-        .onChange(of: backgroundMapDetails.scale) {
+        .onChange(of: backgroundMapDetails.mapCamera.distance) {
             Task {
                 let positions = await calculateSSlineEndPos()
                 DispatchQueue.main.async { self.lineEnds = positions }

--- a/Map Map/Background Map/Background Map Layers/BackgroundMapPointsV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapPointsV.swift
@@ -113,19 +113,7 @@ struct BackgroundMapPointsV: View {
             .animation(.linear, value: ssUserLocation)
         }
         .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextObjectsDidChange)) { interpretCDNotification($0) }
-        .onChange(of: backgroundMapDetails.region.center) {
-            Task {
-                let positions = await calculateSSlineEndPos()
-                DispatchQueue.main.async { self.lineEnds = positions }
-            }
-        }
-        .onChange(of: backgroundMapDetails.mapCamera.heading) {
-            Task {
-                let positions = await calculateSSlineEndPos()
-                DispatchQueue.main.async { self.lineEnds = positions }
-            }
-        }
-        .onChange(of: backgroundMapDetails.mapCamera.distance) {
+        .onChange(of: backgroundMapDetails.mapCamera) {
             Task {
                 let positions = await calculateSSlineEndPos()
                 DispatchQueue.main.async { self.lineEnds = positions }

--- a/Map Map/MapMap Editing/MapMapEditorV.swift
+++ b/Map Map/MapMap Editing/MapMapEditorV.swift
@@ -69,11 +69,11 @@ struct MapMapEditor: View {
                     }
                     HStack {
                         Button(action: {
-                            mapMap.coordinates = backgroundMapDetails.position
-                            mapMap.mapMapRotation = backgroundMapDetails.rotation.degrees
-                            mapMap.mapMapScale = mapMapPosition.width / backgroundMapDetails.scale
+                            mapMap.coordinates = backgroundMapDetails.region.center
+                            mapMap.mapMapRotation = -backgroundMapDetails.mapCamera.heading
+                            mapMap.mapMapScale = mapMapPosition.width * backgroundMapDetails.mapCamera.distance
                             mapMap.mapMapName = workingName
-                            mapMap.mapDistance = 1 / backgroundMapDetails.scale
+                            mapMap.mapDistance = backgroundMapDetails.mapCamera.distance
                             mapMap.isEditing = false
                             mapMap.isSetup = true
                             if let overlappingMarkers = MapMapEditor.mapMapOverMarkers(

--- a/Map Map/Marker Editor/MarkerEditorV.swift
+++ b/Map Map/Marker Editor/MarkerEditorV.swift
@@ -90,8 +90,8 @@ struct MarkerEditorV: View {
                             Button {
                                 marker.isEditing = false
                                 marker.name = workingName
-                                marker.coordinates = backgroundMapDetails.position
-                                marker.lockRotationAngleDouble = saveAngle ? backgroundMapDetails.rotation.degrees : nil
+                                marker.coordinates = backgroundMapDetails.region.center
+                                marker.lockRotationAngleDouble = saveAngle ? -backgroundMapDetails.mapCamera.heading : nil
                                 determineMarkerOverlap()
                                 try? moc.save()
                             } label: {


### PR DESCRIPTION
Background Map Details has been simplified to reduce the number of assignments required to update background map details.

This reduction makes it easier to observe changes since only the map camera needs to be observed to observe when the map changes.