### PR TITLE
20 Markers Don't Sort from Marker Editor

### DIFF
--- a/Map Map/Background Map/Background Map Layers/BackgroundMapButtonsV.swift
+++ b/Map Map/Background Map/Background Map Layers/BackgroundMapButtonsV.swift
@@ -123,16 +123,13 @@ struct BackgroundMapButtonsV: View {
     
     func addMarker() {
         let newMarker = Marker(coordinates: backgroundMapDetails.position, insertInto: moc)
-        let centerPoint: CGPoint = CGPoint(size: screenSize / 2)
-        for mapMap in mapMaps {
-            if let path = BackgroundMap.generateMapMapRotatedConvexHull(
-                mapMap: mapMap,
-                backgroundMapDetails: backgroundMapDetails,
-                mapContext: mapContext
-            )?.cgPath,
-               path.contains(centerPoint) {
-                newMarker.addToMapMap(mapMap)
-            }
+        if let overlappedMapMaps = MarkerEditorV.markerOverMapMaps(
+            newMarker,
+            backgroundMapDetails: backgroundMapDetails,
+            mapContext: mapContext,
+            mapMaps: mapMaps
+        ) {
+            for mapMap in overlappedMapMaps { newMarker.addToMapMap(mapMap) }
         }
         try? moc.save()
     }

--- a/Map Map/Marker Editor/MarkerEditorV.swift
+++ b/Map Map/Marker Editor/MarkerEditorV.swift
@@ -127,8 +127,7 @@ struct MarkerEditorV: View {
             backgroundMapDetails: backgroundMapDetails,
             mapContext: mapContext,
             mapMaps: mapMaps
-        )
-            /*screenSpacePositions.markerOverMapMaps(marker, backgroundMapRotation: backgroundMapDetails.rotation)*/ {
+        ) {
             // Remove current marker from all MapMaps
             for mapMap in marker.formattedMapMaps { mapMap.removeFromMarkers(marker) }
             // Add Marker to relevant MapMaps
@@ -152,7 +151,7 @@ struct MarkerEditorV: View {
         guard let markerPosition = mapContext.convert(marker.coordinates, to: .global)
         else { return nil }
         let marker = MarkerEditorV.generateMarkerBoundingBox(markerPosition: markerPosition)
-        var mapMaps: [MapMap] = []
+        var overlappingMapMaps: [MapMap] = []
         for mapMap in mapMaps {
             if let mapMapBounds = BackgroundMap.generateMapMapRotatedConvexHull(
                 mapMap: mapMap,
@@ -160,10 +159,10 @@ struct MarkerEditorV: View {
                 mapContext: mapContext
             )?.cgPath,
                 mapMapBounds.intersects(marker) {
-                mapMaps.append(mapMap)
+                overlappingMapMaps.append(mapMap)
             }
         }
-        return mapMaps
+        return overlappingMapMaps
     }
     
     /// Generate a Marker's bounding box


### PR DESCRIPTION
Markers were previously not sorting into Map Maps if they were at some point edited. Additionally, The add Marker button was not using the logic from the Marker editor to do so, partially obscuring the error.