### PR TITLE
Force camera unavailable text to be white

### DIFF
--- a/Map Map/Camera/CameraPreviewV.swift
+++ b/Map Map/Camera/CameraPreviewV.swift
@@ -62,6 +62,7 @@ struct CameraPreviewV: View {
                             Text("Camera permissions are not enabled.")
                             Text("Open Settings to optionally enable the camera for MapMap.")
                         }
+                        .foregroundStyle(.white)
                     }
                 }
             }


### PR DESCRIPTION
Force camera unavailable text to be white, even in light mode.