### PR TITLE
124 gps map timer is slow to start

### DIFF
--- a/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
+++ b/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
@@ -99,7 +99,10 @@ struct TrackingGpsDrawerContentV: View {
         .animation(.easeInOut(duration: 0.25), value: showDoneConfirmation)
         .animation(.easeInOut(duration: 0.25), value: statsBottom)
         .onReceive(timer) { _ in
-            let newTime: Int = -Int(gpsMap.unwrappedConnections.last?.end?.timestamp?.timeIntervalSinceNow ?? 0.0)
+            let newTime: Int
+            if let endTime = gpsMap.unwrappedConnections.last?.end?.timestamp?.timeIntervalSinceNow { newTime = Int(-endTime) }
+            else if let startTime = gpsMap.unwrappedConnections.last?.start?.timestamp?.timeIntervalSinceNow { newTime = Int(-startTime) }
+            else { newTime = 0 }
             if newTime != self.additionalTime { self.additionalTime = newTime }
             updateLiveActivity()
         }

--- a/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
+++ b/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
@@ -106,7 +106,7 @@ struct TrackingGpsDrawerContentV: View {
             if newTime != self.additionalTime { self.additionalTime = newTime }
             updateLiveActivity()
         }
-        .onChange(of: locationsHandler.lastLocation) { _ = gpsMap.addNewCoordinate(clLocation: $1) }
+        .onChange(of: locationsHandler.lastLocation, initial: true) { _ = gpsMap.addNewCoordinate(clLocation: $1)}
         .onChange(of: gpsMap.connections?.count) {
             self.additionalTime = 0
             self.speed = Measurement(value: Double(gpsMap.distance) / (gpsMap.time), unit: .metersPerSecond)


### PR DESCRIPTION
Fix the GPS Map Timer being slow to start by checking the first half of the connection if the end isn't available, and adding the user's initial location instead of waiting for an update.