### PR TITLE
126 gpsmap nan speed

### DIFF
--- a/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
+++ b/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
@@ -106,7 +106,7 @@ struct TrackingGpsDrawerContentV: View {
             if newTime != self.additionalTime { self.additionalTime = newTime }
             updateLiveActivity()
         }
-        .onChange(of: locationsHandler.lastLocation, initial: true) { _ = gpsMap.addNewCoordinate(clLocation: $1)}
+        .onChange(of: locationsHandler.lastLocation, initial: true) { _ = gpsMap.addNewCoordinate(clLocation: $1) }
         .onChange(of: gpsMap.connections?.count) {
             self.additionalTime = 0
             self.speed = Measurement(value: Double(gpsMap.distance) / (gpsMap.time), unit: .metersPerSecond)

--- a/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
+++ b/Map Map/GPS Map Editor/TrackingGpsDrawerContentV.swift
@@ -109,7 +109,8 @@ struct TrackingGpsDrawerContentV: View {
         .onChange(of: locationsHandler.lastLocation, initial: true) { _ = gpsMap.addNewCoordinate(clLocation: $1) }
         .onChange(of: gpsMap.connections?.count) {
             self.additionalTime = 0
-            self.speed = Measurement(value: Double(gpsMap.distance) / (gpsMap.time), unit: .metersPerSecond)
+            let proposedSpeed: Measurement<UnitSpeed> = Measurement(value: Double(gpsMap.distance) / (gpsMap.time), unit: .metersPerSecond)
+            self.speed = proposedSpeed.value.isNormal ? proposedSpeed : Measurement<UnitSpeed>(value: 0, unit: .metersPerSecond)
         }
         .onAppear { mapDetails.followUser() }
         .onAppear { setupLiveActivity() }


### PR DESCRIPTION
Fix GPS Maps showing a speed of NaN by ensuring speed is a valid number.
The bug was caused by there being zero time, which only happens when there are 0-2 GPSMapCoordinates