### PR TITLE
Check all available transactions on Store creation

### DIFF
--- a/Map Map/Store/StoreM.swift
+++ b/Map Map/Store/StoreM.swift
@@ -28,9 +28,34 @@ final class Store {
         self.purchasedExplorer = false
         #endif
         self.updateListenerTask = listenForTransactions()
+        Task { await checkExistingTransactions() }
     }
     
     deinit { self.updateListenerTask?.cancel() }
+    
+    /// Check a StoreKit transaction to ensure validity, and set as bought.
+    /// - Parameter result: A verification result from checking available transactions.
+    func checkTransaction(_ result: VerificationResult<StoreKit.Transaction>) async {
+        do {
+            let transaction = try self.checkVerified(result)
+
+            // Deliver products to the user.
+            self.updateCustomerProductStatus(transaction: transaction)
+
+            // Always finish a transaction.
+            await transaction.finish()
+        } catch {
+            // StoreKit has a transaction that fails verification. Don't deliver content to the user.
+            print("Transaction \"", result.unsafePayloadValue.productID, "\"failed verification")
+        }
+    }
+    
+    /// Check every existing transaction
+    func checkExistingTransactions() async {
+        for await result in StoreKit.Transaction.all {
+            await checkTransaction(result)
+        }
+    }
     
     /// Constantly check for the user making a purchase.
     /// - Returns: Task to run in the background.
@@ -38,18 +63,7 @@ final class Store {
         return Task.detached {
             // Iterate through any transactions that don't come from a direct call to `purchase()`.
             for await result in Transaction.updates {
-                do {
-                    let transaction = try self.checkVerified(result)
-
-                    // Deliver products to the user.
-                    self.updateCustomerProductStatus(transaction: transaction)
-
-                    // Always finish a transaction.
-                    await transaction.finish()
-                } catch {
-                    // StoreKit has a transaction that fails verification. Don't deliver content to the user.
-                    print("Transaction failed verification")
-                }
+                await self.checkTransaction(result)
             }
         }
     }


### PR DESCRIPTION
Check all transactions (not just updates) made in Map Map on launch. This is done with async.